### PR TITLE
Minor changes to f-string prompts.

### DIFF
--- a/pixel_puzzle/pixel_puzzle.py
+++ b/pixel_puzzle/pixel_puzzle.py
@@ -76,7 +76,7 @@ def shuffle_pixels(origin_image: str,
         )
     except KeyError:
         print(
-            f"Invalid selection of image quality {image_quality}. "
+            f'Invalid selection of image quality: "{image_quality}". '
         )
 
 
@@ -124,7 +124,7 @@ def recover_pixels(shuffled_image: str,
         )
     except KeyError:
         print(
-            f"Invalid selection of image quality {image_quality}. "
+            f'Invalid selection of image quality: "{image_quality}". '
         )
 
 


### PR DESCRIPTION
Added double quotes to f-string prompts after `except KeyError:` of `shuffle_pixels()` and `recover_pixels()`.